### PR TITLE
Fix attachments code

### DIFF
--- a/src/data/attachment.php
+++ b/src/data/attachment.php
@@ -25,7 +25,7 @@ class AttachmentDataController extends DataController {
         // Remove all non alpahnum characters from filename - allow international chars, dash, underscore, and period
         $filename = preg_replace('/[^\p{L}\p{N}_\-.]+/u', '_', $filename);
 
-        $data = readfile(Attachment::attachmentsDir.$filename);
+        $data = file_get_contents(Attachment::attachmentsDir.$filename);
       }
     }
 


### PR DESCRIPTION
When downloading an attachment, the byte length of the file is appended, see issue #617.